### PR TITLE
Add waypoint path generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ python simulation.py
 ```
 
 The simulation now computes a reference attitude `R_ref` on each step so the
-vehicle tilts toward the target position.  This allows the quadrotor to move in
-the horizontal `x` and `y` directions in addition to holding altitude.
+vehicle tilts toward the target position. The path to the goal can be divided
+into intermediate waypoints by setting the ``n_segments`` parameter of
+``simulate``. This allows gentler control toward the target.
 
 ## Testing
 The project uses `pytest` for testing (no tests are currently implemented). Run:


### PR DESCRIPTION
## Summary
- add helper to generate intermediate reference points
- track waypoint progression inside Quadrotor and expose `n_segments` option in `simulate`
- document `n_segments` usage in README

## Testing
- `pytest`
- `python simulation.py` *(fails: numpy missing; attempt to `pip install numpy matplotlib` blocked by proxy)*

------