### PR TITLE
Separate path segments from simulation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ python simulation.py
 
 The simulation now computes a reference attitude `R_ref` on each step so the
 vehicle tilts toward the target position. The path to the goal can be divided
-into intermediate waypoints by setting the ``n_segments`` parameter of
-``simulate``. This allows gentler control toward the target.
+into intermediate waypoints by setting the ``segments`` parameter of
+``simulate``. This controls how finely the path is subdivided and is independent
+of the number of simulation steps, allowing gentler control toward the target.
 
 ## Testing
 The project uses `pytest` for testing (no tests are currently implemented). Run:

--- a/simulation.py
+++ b/simulation.py
@@ -203,21 +203,28 @@ class Quadrotor:
 
 
 def simulate(
-    steps: int = 100, target: np.ndarray | None = None, n_segments: int = 10
+    steps: int = 100, target: np.ndarray | None = None, segments: int = 10
 ):
     """Run a simple path-following simulation.
 
-    ``n_segments`` may be larger than the number of simulation steps. In that
-    case only the first ``steps`` segments are required, so the waypoint list is
-    capped to avoid allocating unnecessary points.
+    Parameters
+    ----------
+    steps:
+        Number of simulation iterations to perform.
+    target:
+        Final position for the quadrotor.  If ``None`` a default target is
+        used.
+    segments:
+        Number of path segments between the current position and ``target``.
+        This affects only the density of waypoints; it is independent of
+        ``steps``.
     """
 
     quad = Quadrotor()
     if target is None:
         target = np.array([1.0, 1.0, 1.0])
 
-    segs = min(n_segments, steps)
-    quad.set_path(generate_reference_points(quad.x, target, segs))
+    quad.set_path(generate_reference_points(quad.x, target, segments))
 
     positions = []
     forces = []


### PR DESCRIPTION
## Summary
- Clarify simulate interface by renaming `n_segments` to `segments` and removing step-based capping
- Update docstring and README to explain that path segmentation is independent of simulation steps

## Testing
- `python -m py_compile simulation.py`
- `pytest`


------