### PR TITLE
Use smooth trajectory and dynamic orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,10 @@ Execute the main script to simulate the quadrotor for 200 steps, print a few sam
 python simulation.py
 ```
 
-The simulation now computes a reference attitude `R_ref` on each step so the
-vehicle tilts toward the target position. The path to the goal can be divided
-into intermediate waypoints by setting the ``segments`` parameter of
-``simulate``. This controls how finely the path is subdivided and is independent
-of the number of simulation steps, allowing gentler control toward the target.
-Waypoints are generated lazily, so extremely large ``segments`` values do not
-consume excessive memory.
+The simulation now computes a reference attitude `R_ref` from the instantaneous
+acceleration at each step so the vehicle tilts toward the target position. A
+smooth cubic trajectory is used so that the quadrotor starts and stops at rest
+while moving from the origin to the goal.
 
 ## Testing
 The project uses `pytest` for testing (no tests are currently implemented). Run:


### PR DESCRIPTION
## Summary
- Replace constant-acceleration trajectory with a cubic profile that starts and ends at rest for more realistic motion.
- Derive orientation reference from each step’s acceleration so the quadrotor tilts toward the changing thrust direction.
- Refresh documentation to mention the per-step attitude and smooth cubic trajectory.

## Testing
- `pytest`
- `python simulation.py` *(fails: numpy is required)*
- `pip install numpy matplotlib pytest` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6891ed35f48883218276b6673ce8ebbe