### PR TITLE
Fine-tune horizontal PID gains for smoother quadrotor response

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ corresponding `R_ref` matrices.  Custom angular-rate profiles may still be
 supplied to override this default behaviour.
 
 PID gains for both position and attitude control are exposed as arguments to
-the `Quadrotor` constructor.  The default values have been tuned to drive the
-vehicle to its goal with minimal overshoot.  For additional adjustments you
-can call the `tune_pid` helper to perform a grid search over a range of PID
-coefficients, evaluating the integrated tracking error, terminal error after a
-hold at the goal, and any overshoot across the entire trajectory.
+the `Quadrotor` constructor. The defaults now use lower proportional and
+derivative gains on the horizontal $x$ and $y$ axes\—$k_p=0.3$ and
+$k_d=1.0$\—which further damp overshoot while leaving the $z$ response
+unchanged. For additional adjustments you can call the `tune_pid` helper to
+perform a grid search over a range of PID coefficients, evaluating the
+integrated tracking error, terminal error after a hold at the goal, and any
+overshoot across the entire trajectory.
 
 ### Custom orientation example
 

--- a/simulation.py
+++ b/simulation.py
@@ -111,10 +111,10 @@ class Quadrotor:
     def __init__(
         self,
         dt: float = 0.01,
-        # PID gains tuned to reach the destination with minimal overshoot
-        k_p: float = 0.5,
+        # PID gains with further damping on x/y to trim overshoot
+        k_p: float = 0.3,
         k_i: float = 0.0,
-        k_d: float = 0.9,
+        k_d: float = 1.0,
         leak: float = 1.0,
         k_pz: float | None = 2.5,
         k_iz: float | None = 0.1,


### PR DESCRIPTION
## Summary
- Lower default x/y PID proportional and derivative gains to 0.3 and 1.0 for more damping
- Document updated gains and mention using `tune_pid` to explore PID grids

## Testing
- `python -m py_compile simulation.py`
- `pytest`


------