### PR TITLE
Add GPR inverse model using thrust/moment features

### DIFF
--- a/data_collection.py
+++ b/data_collection.py
@@ -1,0 +1,33 @@
+"""Random rotor-force data collection for training inverse models."""
+
+try:
+    import numpy as np
+except ImportError as exc:  # pragma: no cover - runtime dependency guard
+    raise SystemExit("numpy required. Install via 'pip install numpy'.") from exc
+
+from simulation import Quadrotor
+
+
+def collect_random_rotor_data(
+    steps: int,
+    force_range: tuple[float, float] = (0.0, 20.0),
+    quad: Quadrotor | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Collect random thrust/torque samples and corresponding rotor forces."""
+    if quad is None:
+        quad = Quadrotor()
+    A_alloc = np.array(
+        [
+            [1, 1, 1, 1],
+            [0, -quad.l, 0, quad.l],
+            [quad.l, 0, -quad.l, 0],
+            [-quad.c_t, quad.c_t, -quad.c_t, quad.c_t],
+        ]
+    )
+    X, y = [], []
+    for _ in range(steps):
+        forces = np.random.uniform(force_range[0], force_range[1], size=4)
+        TM = A_alloc @ forces
+        X.append(TM)
+        y.append(forces)
+    return np.array(X), np.array(y)

--- a/gpr_demo.py
+++ b/gpr_demo.py
@@ -1,0 +1,35 @@
+"""Demonstration of training a GPR inverse model and running quadrotor control."""
+
+import numpy as np
+
+from data_collection import collect_random_rotor_data
+from gpr_inverse import train_inverse_gpr
+from simulation import Quadrotor, simulate
+
+
+def main() -> None:
+    # 1. Collect random data
+    X, y = collect_random_rotor_data(steps=2000)
+    print(f"Collected dataset: X{X.shape}, y{y.shape}")
+
+    # 2. Train GPR inverse model
+    model = train_inverse_gpr(X, y)
+    print("Trained GPR inverse model")
+
+    # 3. Compare baseline control and GPR-based control
+    target = np.array([1.0, 1.0, 1.0])
+
+    steps = 400
+    base_quad = Quadrotor()
+    pos_base, *_ = simulate(steps=steps, target=target, quad=base_quad)
+    err_base = np.linalg.norm(pos_base[-1] - target)
+    print(f"Final position ideal allocation: {pos_base[-1]}, error {err_base:.3f}")
+
+    gpr_quad = Quadrotor(gpr_model=model, use_gpr=True)
+    pos_gpr, *_ = simulate(steps=steps, target=target, quad=gpr_quad)
+    err_gpr = np.linalg.norm(pos_gpr[-1] - target)
+    print(f"Final position with GPR control: {pos_gpr[-1]}, error {err_gpr:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gpr_inverse.py
+++ b/gpr_inverse.py
@@ -1,0 +1,59 @@
+"""Gaussian Process Regression based inverse mapping from accel/orientation to rotor forces."""
+
+try:
+    import numpy as np
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("numpy required. Install via 'pip install numpy'.") from exc
+
+try:
+    from sklearn.gaussian_process import GaussianProcessRegressor
+    from sklearn.gaussian_process.kernels import RBF, WhiteKernel
+    from sklearn.preprocessing import StandardScaler
+except Exception as exc:  # pragma: no cover - optional dependency guard
+    raise SystemExit(
+        "scikit-learn required for GPR. Install via 'pip install scikit-learn'."
+    ) from exc
+
+import pickle
+from dataclasses import dataclass
+
+
+@dataclass
+class InverseGPR:
+    """Container holding a trained GPR model and feature/target scalers."""
+
+    gpr: GaussianProcessRegressor
+    x_scaler: StandardScaler
+    y_scaler: StandardScaler
+
+
+def train_inverse_gpr(X: np.ndarray, y: np.ndarray) -> InverseGPR:
+    """Train a GaussianProcessRegressor with standardized inputs/outputs."""
+    x_scaler = StandardScaler()
+    y_scaler = StandardScaler()
+    Xs = x_scaler.fit_transform(X)
+    ys = y_scaler.fit_transform(y)
+
+    kernel = RBF(length_scale=1.0) + WhiteKernel(noise_level=1e-3)
+    gpr = GaussianProcessRegressor(kernel=kernel, alpha=1e-3, normalize_y=False)
+    gpr.fit(Xs, ys)
+    return InverseGPR(gpr, x_scaler, y_scaler)
+
+
+def predict_forces(model: InverseGPR, X_query: np.ndarray) -> np.ndarray:
+    """Predict rotor forces given query features."""
+    Xs = model.x_scaler.transform(X_query)
+    ys = model.gpr.predict(Xs)
+    return model.y_scaler.inverse_transform(ys)
+
+
+def save_model(model: InverseGPR, path: str) -> None:
+    """Serialize GPR model to disk."""
+    with open(path, "wb") as f:
+        pickle.dump(model, f)
+
+
+def load_model(path: str) -> InverseGPR:
+    """Load a serialized GPR model from disk."""
+    with open(path, "rb") as f:
+        return pickle.load(f)


### PR DESCRIPTION
## Summary
- Collect thrust and moment data pairs for training the inverse model
- Train a scaled GPR mapping from desired thrust/moment to rotor forces
- Use the learned inverse in the quadrotor simulation and compare with ideal allocation

## Testing
- `python -m py_compile simulation.py data_collection.py gpr_inverse.py gpr_demo.py`
- `python gpr_demo.py`


------