### PR TITLE
Add MR-GPR comparison to simulation outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install numpy matplotlib pillow
 ```
 
 ## Running the simulation
-Execute the main script to simulate the quadrotor for 200 steps and then hold at the goal, printing a few sample states and generating `trajectory.png` and an animated `trajectory.gif` showing the reference and actual 3-D paths:
+Execute the main script to simulate the quadrotor for 200 steps and then hold at the goal.  The script now trains a small MR-GPR inverse model and runs both the ideal inverse allocation and MR-GPR-based allocation, printing a few sample states and generating `trajectory.png` and an animated `trajectory.gif` comparing the reference, ideal, and MR-GPR 3-D paths:
 
 ```bash
 python simulation.py


### PR DESCRIPTION
## Summary
- Train an MR-GPR inverse model and run parallel quadrotor simulations for ideal and MR-GPR control.
- Overlay MR-GPR results on trajectory plots and 3-D GIF animation.
- Update documentation to describe new comparison capability.

## Testing
- `python -m py_compile simulation.py`
- `python - <<'PY'
from simulation import simulate, Quadrotor
from data_collection import collect_random_rotor_data
from gpr_inverse import train_inverse_gpr
import numpy as np
X, y = collect_random_rotor_data(steps=50)
model = train_inverse_gpr(X, y)
quad = Quadrotor(gpr_model=model, use_gpr=True)
pos, _, _, _, x_refs, _, _, _ = simulate(20, hold_steps=5, quad=quad)
print('positions shape', pos.shape)
print('refs shape', x_refs.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e767182888321ad20272fce9ac60f