### PR TITLE
Add residual MR-GPR allocator and experiment

### DIFF
--- a/data_collection_residual.py
+++ b/data_collection_residual.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Data collection utilities for residual GPR training."""
+
+from typing import Tuple
+
+import numpy as np
+
+from simulation import Quadrotor, simulate
+
+
+class RecorderQuadrotor(Quadrotor):
+    """Quadrotor wrapper to capture features and nominal forces for training."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.last_phi: np.ndarray | None = None
+        self.last_forces_nom: np.ndarray | None = None
+
+    def rotor_forces(self, T: float, M: np.ndarray):
+        # Compute nominal forces without saturation and record
+        A_alloc = np.array(
+            [
+                [1, 1, 1, 1],
+                [0, -self.l, 0, self.l],
+                [self.l, 0, -self.l, 0],
+                [-self.c_t, self.c_t, -self.c_t, self.c_t],
+            ]
+        )
+        TM = np.concatenate(([T], M))
+        forces_nom = np.linalg.pinv(A_alloc) @ TM
+        self.last_forces_nom = forces_nom.copy()
+
+        ez = np.array([0.0, 0.0, 1.0])
+        Re = self.R @ ez
+        self.last_phi = np.concatenate(([T], M, Re, self.omega))
+
+        # Continue with nominal saturation behaviour
+        forces_unc = np.linalg.pinv(A_alloc) @ TM
+        forces = np.clip(forces_unc, 0.0, self.max_force)
+        TM_act = A_alloc @ forces
+        return forces, float(TM_act[0]), TM_act[1:]
+
+
+def collect_residual_data(
+    steps: int = 2000,
+    target: np.ndarray | None = None,
+    hold_steps: int = 200,
+    seed: int = 0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Collect training data for residual GPR.
+
+    Returns
+    -------
+    X : ndarray of shape (N, 10)
+        Features ``[T, Mx, My, Mz, (R@ez), omega]``.
+    Y : ndarray of shape (N, 4)
+        Residuals ``f_true - f_nom``.
+    """
+
+    rng = np.random.default_rng(seed)
+    if target is None:
+        target = np.array([1.0, 1.0, 1.0])
+
+    quad = RecorderQuadrotor()
+
+    # Warm start to populate initial state
+    simulate(200, target=target, hold_steps=hold_steps, quad=quad)
+
+    Xs, Ys = [], []
+    # Hidden actuator model parameters
+    gains = rng.uniform(0.9, 1.1, size=4)
+    biases = rng.uniform(-0.5, 0.5, size=4)
+
+    for _ in range(steps):
+        goal = rng.uniform(0.5, 1.2, size=3)
+        simulate(60, target=goal, hold_steps=10, quad=quad)
+
+        if quad.last_phi is None or quad.last_forces_nom is None:
+            continue
+        phi = quad.last_phi
+        f_nom = quad.last_forces_nom
+
+        # Synthesize "true" forces with bias/gain/noise and saturation
+        f_true = gains * f_nom + biases + rng.normal(0.0, 0.05, size=4)
+        f_true = np.clip(f_true, 0.0, quad.max_force)
+        delta = f_true - f_nom
+
+        Xs.append(phi)
+        Ys.append(delta)
+
+    return np.array(Xs), np.array(Ys)

--- a/residual_allocator.py
+++ b/residual_allocator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Quadrotor subclass that applies residual GPR corrections to rotor forces."""
+
+from typing import Tuple
+
+import numpy as np
+
+from residual_gpr import ResidualMRGPR
+from simulation import Quadrotor
+
+
+class ResidualQuadrotor(Quadrotor):
+    """Quadrotor with residual-based rotor allocation using a GPR model."""
+
+    def __init__(
+        self,
+        residual_model: ResidualMRGPR,
+        residual_trust_scale: float = 1.0,
+        residual_var_clip: float = 5.0,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.residual_model = residual_model
+        self.residual_trust_scale = residual_trust_scale
+        self.residual_var_clip = residual_var_clip
+
+    def _features_for_residual(self, T: float, M: np.ndarray) -> np.ndarray:
+        ez = np.array([0.0, 0.0, 1.0])
+        Re = self.R @ ez
+        return np.concatenate(([T], M, Re, self.omega))
+
+    def rotor_forces(self, T: float, M: np.ndarray) -> Tuple[np.ndarray, float, np.ndarray]:
+        """Override rotor allocation with residual GPR correction."""
+
+        # Nominal inverse allocation (no saturation)
+        A_alloc = np.array(
+            [
+                [1, 1, 1, 1],
+                [0, -self.l, 0, self.l],
+                [self.l, 0, -self.l, 0],
+                [-self.c_t, self.c_t, -self.c_t, self.c_t],
+            ]
+        )
+        TM = np.concatenate(([T], M))
+        forces_nom = np.linalg.pinv(A_alloc) @ TM
+
+        # Residual prediction
+        phi = self._features_for_residual(T, M).reshape(1, -1)
+        mu, var = self.residual_model.predict(phi)
+        mu, var = mu[0], var[0]
+
+        # Variance-based gating
+        w = self.residual_trust_scale * (1.0 / (1.0 + (var / self.residual_var_clip)))
+        forces = forces_nom + w * mu
+        forces = np.clip(forces, 0.0, self.max_force)
+
+        TM_act = A_alloc @ forces
+        return forces, float(TM_act[0]), TM_act[1:]

--- a/residual_gpr.py
+++ b/residual_gpr.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Residual Gaussian Process Regression model for rotor-force deltas."""
+
+from typing import Tuple
+
+import numpy as np
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import RBF, WhiteKernel
+
+
+class ResidualMRGPR:
+    """Predict rotor force residuals (delta forces) using independent GPRs."""
+
+    def __init__(self, input_dim: int):
+        kernel = RBF(
+            length_scale=np.ones(input_dim),
+            length_scale_bounds=(1e-3, 1e3),
+        ) + WhiteKernel(noise_level=1e-3, noise_level_bounds=(1e-6, 1e1))
+        # Maintain four independent models for simplicity/performance.
+        self.models = [
+            GaussianProcessRegressor(kernel=kernel, normalize_y=True) for _ in range(4)
+        ]
+        self.input_dim = input_dim
+
+    def fit(self, X: np.ndarray, Y: np.ndarray) -> None:
+        """Fit all rotor residual models.
+
+        Parameters
+        ----------
+        X: np.ndarray
+            Training features with shape ``(N, input_dim)``.
+        Y: np.ndarray
+            Residual forces with shape ``(N, 4)`` where ``Y = f_true - f_nom``.
+        """
+
+        for i in range(4):
+            self.models[i].fit(X, Y[:, i])
+
+    def predict(self, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Predict residual means and variances for each rotor.
+
+        Parameters
+        ----------
+        X: np.ndarray
+            Query features with shape ``(N, input_dim)``.
+
+        Returns
+        -------
+        Tuple[np.ndarray, np.ndarray]
+            A tuple ``(mean, var)`` each of shape ``(N, 4)`` where values are
+            stacked across the four independent GPR models.
+        """
+
+        means, vars_ = [], []
+        for i in range(4):
+            m, v = self.models[i].predict(X, return_std=True)
+            means.append(m)
+            vars_.append(v**2)
+        return np.stack(means, axis=1), np.stack(vars_, axis=1)

--- a/run_residual_experiment.py
+++ b/run_residual_experiment.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Train and compare baseline, absolute MR-GPR, and residual MR-GPR."""
+
+import numpy as np
+
+from data_collection import collect_random_rotor_data
+from data_collection_residual import collect_residual_data
+from gpr_inverse import train_inverse_gpr
+from residual_allocator import ResidualQuadrotor
+from residual_gpr import ResidualMRGPR
+from simulation import Quadrotor, simulate
+
+
+def main() -> None:
+    # 1) Collect residual training data and train residual model
+    X_res, Y_res = collect_residual_data(steps=3000)
+    model_res = ResidualMRGPR(input_dim=X_res.shape[1])
+    model_res.fit(X_res, Y_res)
+
+    # 2) Absolute MR-GPR model (existing path)
+    X_abs, y_abs = collect_random_rotor_data(steps=200)
+    model_abs = train_inverse_gpr(X_abs, y_abs)
+
+    # 3) Run simulations for the three approaches
+    quad_nom = Quadrotor()
+    pos_nom, forces_nom, err_nom, *_ = simulate(200, hold_steps=400, quad=quad_nom)
+
+    quad_abs = Quadrotor(gpr_model=model_abs, use_gpr=True)
+    pos_abs, forces_abs, err_abs, *_ = simulate(200, hold_steps=400, quad=quad_abs)
+
+    quad_res = ResidualQuadrotor(residual_model=model_res)
+    pos_res, forces_res, err_res, *_ = simulate(200, hold_steps=400, quad=quad_res)
+
+    # 4) Metric comparison
+    def metrics(pos: np.ndarray) -> tuple[float, np.ndarray]:
+        target = np.array([1.0, 1.0, 1.0])
+        final_err = np.linalg.norm(pos[-1] - target)
+        overshoot_xy = np.maximum(pos - target, 0.0)[:, :2].max(axis=0)
+        return final_err, overshoot_xy
+
+    for name, pos in [
+        ("baseline", pos_nom),
+        ("abs-gpr", pos_abs),
+        ("res-gpr", pos_res),
+    ]:
+        fe, ov = metrics(pos)
+        print(f"{name}: final_err={fe:.4f}, overshoot_xy={ov}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Implement `ResidualMRGPR` model to learn rotor-force residuals
- Add `ResidualQuadrotor` allocator applying residual corrections
- Provide data collection and experiment scripts for residual MR-GPR

## Testing
- `pytest`
- `python - <<'PY'
from data_collection_residual import collect_residual_data
from residual_gpr import ResidualMRGPR
from residual_allocator import ResidualQuadrotor
from simulation import simulate, Quadrotor
import numpy as np

X_res, Y_res = collect_residual_data(steps=100)
model_res = ResidualMRGPR(input_dim=X_res.shape[1])
model_res.fit(X_res, Y_res)
quad_nom = Quadrotor()
pos_nom, _, _, *_ = simulate(50, hold_steps=10, quad=quad_nom)
quad_res = ResidualQuadrotor(residual_model=model_res)
pos_res, forces_res, _, *_ = simulate(50, hold_steps=10, quad=quad_res)
print('baseline:', np.linalg.norm(pos_nom[-1]-np.array([1,1,1])))
print('res-gpr:', np.linalg.norm(pos_res[-1]-np.array([1,1,1])))
print('force range:', forces_res.min(), forces_res.max())
PY`

------