### PR TITLE
Add offline correction sanity-check script and variance gating override

### DIFF
--- a/control/controller_mrgpr_slots.py
+++ b/control/controller_mrgpr_slots.py
@@ -20,6 +20,15 @@ class MRGPBlockController(RealQuadrotor):
         trust_scale_r: float = 1.0,
         var_clip_y: float = 1e6,
         var_clip_r: float = 1e6,
+        ignore_var_trust: bool = False,
+        cond_aware: bool = False,
+        cond_ref: float = 1e3,
+        ood_aware: bool = False,
+        ood_ref: float = 3.0,
+        cap_y_ratio: float = 0.5,
+        cap_y_abs: float = 2.0,
+        cap_r_ratio: float = 0.5,
+        cap_r_abs: float = 0.5,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -30,13 +39,36 @@ class MRGPBlockController(RealQuadrotor):
         self.ts_r = trust_scale_r
         self.clip_y = var_clip_y
         self.clip_r = var_clip_r
+        self.ignore_var_trust = ignore_var_trust
+        self.cond_aware = cond_aware
+        self.cond_ref = cond_ref
+        self.ood_aware = ood_aware
+        self.ood_ref = ood_ref
+        self.cap_y_ratio = cap_y_ratio
+        self.cap_y_abs = cap_y_abs
+        self.cap_r_ratio = cap_r_ratio
+        self.cap_r_abs = cap_r_abs
+
         self.x_hist: list[np.ndarray] = []
         self.R_hist: list[np.ndarray] = []
         self.u_hist: list[np.ndarray] = []
         self.u_log: list[np.ndarray] = []
         self.last_u: np.ndarray | None = None
         self.debug = bool(kwargs.pop("debug", False))
-        self.applied_stats = {"dy_norm": [], "wy_norm": [], "wr_norm": [], "dxi_norm": []}
+        self.applied_stats = {
+            "dy_norm": [],
+            "wy_l2": [],
+            "wy_mean": [],
+            "dxi_norm": [],
+            "wr_l2": [],
+            "wr_mean": [],
+            "vy_mean": [],
+            "vr_mean": [],
+            "cond_pre": [],
+        }
+        self.step_total = 0
+        self.feature_steps = 0
+        self.applied_steps = 0
 
     def _zeta1(self) -> np.ndarray | None:
         if len(self.x_hist) < 4 or len(self.R_hist) < 2 or len(self.u_hist) < 3:
@@ -55,6 +87,7 @@ class MRGPBlockController(RealQuadrotor):
         yaw_ref: float = 0.0,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, float, float]:
         # history update
+        self.step_total += 1
         self.x_hist.append(self.x.copy())
         self.R_hist.append(self.R.copy())
         if self.last_u is not None:
@@ -81,36 +114,98 @@ class MRGPBlockController(RealQuadrotor):
         if z1 is None:
             T, M, condA, off_diag = self.ctrl.block_inverse(x2, x3, x4_nom, R1, R2_nom)
         else:
+            self.feature_steps += 1
             Xy_run = np.concatenate([z1, y_nom])
             xi2_nom = so3_log(R1.T @ R2_nom)
             xr_run = np.concatenate([z1, xi2_nom])
+
+            ez = np.array([0.0, 0.0, 1.0])
+            A_pre = np.column_stack((self.R @ ez, R1 @ ez, R2_nom @ ez))
+            cond_pre = float(np.linalg.cond(A_pre))
+            if not np.isfinite(cond_pre):
+                cond_pre = 1e12
+
             dy, vy = self.gp_y.predict(Xy_run[None, :])
-            wy = self.ts_y * (1.0 / (1.0 + vy[0] / self.clip_y))
             dxi, vr = self.gp_r.predict(xr_run[None, :])
-            wr = self.ts_r * (1.0 / (1.0 + vr[0] / self.clip_r))
-            y_corr_flat = y_nom + wy * dy[0]
-            y0_corr = y_corr_flat[0:3]
-            y1_corr = y_corr_flat[3:6]
-            y2_corr = y_corr_flat[6:9]
-            R2 = R2_nom @ exp_SO3((wr * dxi)[0])
+
+            if self.ignore_var_trust:
+                wy = self.ts_y
+                wr = self.ts_r
+            else:
+                wy = self.ts_y * (1.0 / (1.0 + vy[0] / self.clip_y))
+                wr = self.ts_r * (1.0 / (1.0 + vr[0] / self.clip_r))
+
+            cond_scale = 1.0
+            if self.cond_aware:
+                c = max(0.0, cond_pre - self.cond_ref) / max(self.cond_ref, 1e-9)
+                cond_scale = 1.0 / (1.0 + c)
+
+            ood_scale_y = ood_scale_r = 1.0
+            if self.ood_aware:
+                z_y = self.gp_y.scaler.transform(Xy_run[None, :])
+                z_r = self.gp_r.scaler.transform(xr_run[None, :])
+                dz_y = float(np.mean(np.abs(z_y)))
+                dz_r = float(np.mean(np.abs(z_r)))
+
+                def _ood_s(d: float, ref: float) -> float:
+                    k = max(0.0, d - ref) / max(ref, 1e-9)
+                    return 1.0 / (1.0 + k)
+
+                ood_scale_y = _ood_s(dz_y, self.ood_ref)
+                ood_scale_r = _ood_s(dz_r, self.ood_ref)
+
+            wy = wy * cond_scale * ood_scale_y
+            wr = wr * cond_scale * ood_scale_r
+
+            dy_apply = wy * dy[0]
+            y0c, y1c, y2c = dy_apply[0:3], dy_apply[3:6], dy_apply[6:9]
+
+            def _cap_vec(vec: np.ndarray, ref_norm: float, ratio: float, abs_cap: float) -> np.ndarray:
+                n = float(np.linalg.norm(vec))
+                lim = min(ratio * max(ref_norm, 1e-9), abs_cap)
+                if n > lim and n > 0:
+                    vec = vec * (lim / n)
+                return vec
+
+            y0c = _cap_vec(y0c, np.linalg.norm(y0_nom), self.cap_y_ratio, self.cap_y_abs)
+            y1c = _cap_vec(y1c, np.linalg.norm(y1_nom), self.cap_y_ratio, self.cap_y_abs)
+            y2c = _cap_vec(y2c, np.linalg.norm(y2_nom), self.cap_y_ratio, self.cap_y_abs)
+            dy_apply = np.concatenate([y0c, y1c, y2c])
+            y_corr_flat = y_nom + dy_apply
+            y0_corr, y1_corr, y2_corr = y_corr_flat[0:3], y_corr_flat[3:6], y_corr_flat[6:9]
+
+            dxi_apply = (wr * dxi)[0]
+            dxi_apply = _cap_vec(dxi_apply, np.linalg.norm(xi2_nom), self.cap_r_ratio, self.cap_r_abs)
+
+            R2 = R2_nom @ exp_SO3(dxi_apply)
             Y_override = np.column_stack((y0_corr, y1_corr, y2_corr))
             T, M, condA, off_diag = self.ctrl.block_inverse(
                 x2, x3, x4_nom, R1, R2, Y_override=Y_override
             )
-            self.applied_stats["dy_norm"].append(float(np.linalg.norm(dy[0])))
-            self.applied_stats["wy_norm"].append(float(np.linalg.norm(wy)))
-            self.applied_stats["dxi_norm"].append(float(np.linalg.norm(dxi[0])))
-            self.applied_stats["wr_norm"].append(float(np.linalg.norm(wr)))
-            if self.debug and len(self.applied_stats["dy_norm"]) % 50 == 0:
-                print(
-                    "[MRGP] mean||dy||=%.3e  mean||wy||=%.3e  mean||dxi||=%.3e  mean||wr||=%.3e"
-                    % (
-                        np.mean(self.applied_stats["dy_norm"]),
-                        np.mean(self.applied_stats["wy_norm"]),
-                        np.mean(self.applied_stats["dxi_norm"]),
-                        np.mean(self.applied_stats["wr_norm"]),
+            applied = (self.ts_y > 0.0) or (self.ts_r > 0.0)
+            if applied:
+                self.applied_steps += 1
+                self.applied_stats["dy_norm"].append(float(np.linalg.norm(dy[0])))
+                self.applied_stats["wy_l2"].append(float(np.linalg.norm(wy)))
+                self.applied_stats["wy_mean"].append(float(np.mean(wy)))
+                self.applied_stats["dxi_norm"].append(float(np.linalg.norm(dxi[0])))
+                self.applied_stats["wr_l2"].append(float(np.linalg.norm(wr)))
+                self.applied_stats["wr_mean"].append(float(np.mean(wr)))
+                self.applied_stats["vy_mean"].append(float(np.mean(vy)))
+                self.applied_stats["vr_mean"].append(float(np.mean(vr)))
+                self.applied_stats["cond_pre"].append(cond_pre)
+                if self.debug and len(self.applied_stats["dy_norm"]) % 50 == 0:
+                    print(
+                        "[MRGP] mean||dy||=%.3e  mean||wy||=%.3e  mean wy=%.3e  mean||dxi||=%.3e  mean||wr||=%.3e  mean wr=%.3e"
+                        % (
+                            np.mean(self.applied_stats["dy_norm"]),
+                            np.mean(self.applied_stats["wy_l2"]),
+                            np.mean(self.applied_stats["wy_mean"]),
+                            np.mean(self.applied_stats["dxi_norm"]),
+                            np.mean(self.applied_stats["wr_l2"]),
+                            np.mean(self.applied_stats["wr_mean"]),
+                        )
                     )
-                )
 
         forces, T_act, M_act = self.rotor_forces(T, M)
 
@@ -141,3 +236,29 @@ class MRGPBlockController(RealQuadrotor):
             off_diag,
         )
 
+    def get_debug_stats(self) -> dict:
+        total = max(self.step_total, 1)
+        feature_ratio = self.feature_steps / total
+        applied_ratio = self.applied_steps / total
+        mean = lambda lst: float(np.mean(lst)) if lst else 0.0
+        cond_list = self.applied_stats["cond_pre"]
+        if cond_list:
+            cp = np.percentile(cond_list, [50, 90, 99])
+        else:
+            cp = [0.0, 0.0, 0.0]
+        return {
+            "applied_steps": self.applied_steps,
+            "applied_ratio": applied_ratio,
+            "mean_norm_dy": mean(self.applied_stats["dy_norm"]),
+            "mean_norm_wy": mean(self.applied_stats["wy_l2"]),
+            "mean_wy_mean": mean(self.applied_stats["wy_mean"]),
+            "mean_vy": mean(self.applied_stats["vy_mean"]),
+            "mean_norm_dxi": mean(self.applied_stats["dxi_norm"]),
+            "mean_norm_wr": mean(self.applied_stats["wr_l2"]),
+            "mean_wr_mean": mean(self.applied_stats["wr_mean"]),
+            "mean_vr": mean(self.applied_stats["vr_mean"]),
+            "z1_ratio": feature_ratio,
+            "cond_pre_p50": float(cp[0]),
+            "cond_pre_p90": float(cp[1]),
+            "cond_pre_p99": float(cp[2]),
+        }

--- a/scripts/02_train_slots_gp.py
+++ b/scripts/02_train_slots_gp.py
@@ -138,8 +138,8 @@ def main() -> None:
         "calib_r": calib_r,
         "kernel_y": [str(m.kernel_) for m in gp_y.models],
         "kernel_r": [str(m.kernel_) for m in gp_r.models],
-        "temp_y": gp_y.temp.tolist(),
-        "temp_r": gp_r.temp.tolist(),
+        "temps_y": gp_y.temp.tolist(),
+        "temps_r": gp_r.temp.tolist(),
     }
     with open("artifacts/gp_report.json", "w") as fh:
         json.dump(report, fh)

--- a/scripts/03b_offline_apply_check.py
+++ b/scripts/03b_offline_apply_check.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from models.residual_slots_gp import ResidualYSlotsGP, ResidualR2GP
+
+
+def offline_apply_check(
+    *,
+    data: str = "artifacts/slots_td.npz",
+    gp_y: str = "artifacts/gp_y.pkl",
+    gp_r: str = "artifacts/gp_r.pkl",
+    out_json: str = "artifacts/offline_apply_report.json",
+    out_csv: str = "artifacts/offline_apply_dims.csv",
+    skip_calib_check: bool = False,
+    fail_below_y: float = 0.10,
+    fail_below_r: float = 0.10,
+    shuffle_runs: int = 3,
+    seed: int = 0,
+    gp_y_model: Optional[ResidualYSlotsGP] = None,
+    gp_r_model: Optional[ResidualR2GP] = None,
+) -> dict:
+    """Apply GP corrections offline and report RMSE improvements."""
+
+    data_npz = np.load(data)
+    X_y, Y_y = data_npz["X_y"], data_npz["Y_y"]
+    X_r, Y_r = data_npz["X_r"], data_npz["Y_r"]
+
+    gp_y_model = gp_y_model or ResidualYSlotsGP.load(gp_y)
+    gp_r_model = gp_r_model or ResidualR2GP.load(gp_r)
+
+    dy_hat, vy = gp_y_model.predict(X_y)
+    dr_hat, vr = gp_r_model.predict(X_r)
+
+    err_y = Y_y - dy_hat
+    err_r = Y_r - dr_hat
+
+    rmse_y_base = float(np.sqrt(np.mean(Y_y**2)))
+    rmse_y_after = float(np.sqrt(np.mean(err_y**2)))
+    improve_y = (rmse_y_base - rmse_y_after) / max(rmse_y_base, 1e-12)
+
+    rmse_r_base = float(np.sqrt(np.mean(Y_r**2)))
+    rmse_r_after = float(np.sqrt(np.mean(err_r**2)))
+    improve_r = (rmse_r_base - rmse_r_after) / max(rmse_r_base, 1e-12)
+
+    calib_y = float(np.mean(np.abs(err_y) / (np.sqrt(vy) + 1e-9)))
+    calib_r = float(np.mean(np.abs(err_r) / (np.sqrt(vr) + 1e-9)))
+
+    rmse_y_dim_base = np.sqrt(np.mean(Y_y**2, axis=0))
+    rmse_y_dim_after = np.sqrt(np.mean(err_y**2, axis=0))
+    improve_y_dim = (rmse_y_dim_base - rmse_y_dim_after) / (rmse_y_dim_base + 1e-12)
+
+    rmse_r_dim_base = np.sqrt(np.mean(Y_r**2, axis=0))
+    rmse_r_dim_after = np.sqrt(np.mean(err_r**2, axis=0))
+    improve_r_dim = (rmse_r_dim_base - rmse_r_dim_after) / (rmse_r_dim_base + 1e-12)
+
+    rng = np.random.default_rng(seed)
+    sh_y, sh_r = [], []
+    for _ in range(shuffle_runs):
+        perm = rng.permutation(X_y.shape[0])
+        dy_s, _ = gp_y_model.predict(X_y[perm])
+        dr_s, _ = gp_r_model.predict(X_r[perm])
+        err_y_s = Y_y - dy_s
+        err_r_s = Y_r - dr_s
+        rmse_y_s = float(np.sqrt(np.mean(err_y_s**2)))
+        rmse_r_s = float(np.sqrt(np.mean(err_r_s**2)))
+        sh_y.append((rmse_y_base - rmse_y_s) / max(rmse_y_base, 1e-12))
+        sh_r.append((rmse_r_base - rmse_r_s) / max(rmse_r_base, 1e-12))
+
+    shuffle_stats = {
+        "y_improve_mean": float(np.mean(sh_y)),
+        "y_improve_std": float(np.std(sh_y)),
+        "r_improve_mean": float(np.mean(sh_r)),
+        "r_improve_std": float(np.std(sh_r)),
+    }
+
+    report = {
+        "rmse": {
+            "y": {"base": rmse_y_base, "after": rmse_y_after, "improve": improve_y},
+            "r": {"base": rmse_r_base, "after": rmse_r_after, "improve": improve_r},
+        },
+        "calibration": {"y": calib_y, "r": calib_r},
+        "improve_dim": {"y": improve_y_dim.tolist(), "r": improve_r_dim.tolist()},
+        "shuffle": shuffle_stats,
+        "config": {
+            "data": data,
+            "gp_y": gp_y,
+            "gp_r": gp_r,
+            "out_json": out_json,
+            "out_csv": out_csv,
+            "skip_calib_check": skip_calib_check,
+            "fail_below_y": fail_below_y,
+            "fail_below_r": fail_below_r,
+            "shuffle_runs": shuffle_runs,
+            "seed": seed,
+        },
+    }
+
+    os.makedirs(Path(out_json).parent, exist_ok=True)
+    with open(out_json, "w") as fh:
+        json.dump(report, fh)
+
+    try:
+        import csv
+        with open(out_csv, "w", newline="") as cf:
+            w = csv.writer(cf)
+            w.writerow(["target", "improve"])
+            for i, val in enumerate(improve_y_dim):
+                w.writerow([f"dy[{i}]", float(val)])
+            for i, val in enumerate(improve_r_dim):
+                w.writerow([f"dr[{i}]", float(val)])
+    except Exception as e:
+        print(f"[WARN] failed to write per-dim CSV: {e}")
+
+    return report
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--data", type=str, default="artifacts/slots_td.npz")
+    p.add_argument("--gp-y", type=str, default="artifacts/gp_y.pkl")
+    p.add_argument("--gp-r", type=str, default="artifacts/gp_r.pkl")
+    p.add_argument("--out-json", type=str, default="artifacts/offline_apply_report.json")
+    p.add_argument("--out-csv", type=str, default="artifacts/offline_apply_dims.csv")
+    p.add_argument("--skip-calib-check", action="store_true")
+    p.add_argument("--fail-below-y", type=float, default=0.10)
+    p.add_argument("--fail-below-r", type=float, default=0.10)
+    p.add_argument("--shuffle-runs", type=int, default=3)
+    p.add_argument("--seed", type=int, default=0)
+    args = p.parse_args()
+
+    report = offline_apply_check(**vars(args))
+
+    rm_y = report["rmse"]["y"]
+    rm_r = report["rmse"]["r"]
+    sh = report["shuffle"]
+    print(
+        f"Δy: RMSE {rm_y['base']:.3f} -> {rm_y['after']:.3f} (improve {100*rm_y['improve']:.1f}%)"
+    )
+    print(
+        f"Δξ2: RMSE {rm_r['base']:.3f} -> {rm_r['after']:.3f} (improve {100*rm_r['improve']:.1f}%)"
+    )
+    print(
+        f"Shuffle Δy improve {100*sh['y_improve_mean']:.1f}±{100*sh['y_improve_std']:.1f}%", 
+        f"Δξ2 improve {100*sh['r_improve_mean']:.1f}±{100*sh['r_improve_std']:.1f}%",
+    )
+    print(
+        f"Calibration: y={report['calibration']['y']:.3f} r={report['calibration']['r']:.3f}"
+    )
+
+    calib_ok = 0.7 <= report["calibration"]["y"] <= 1.3 and 0.7 <= report["calibration"]["r"] <= 1.3
+    pass_cond = (
+        rm_y["improve"] >= args.fail_below_y
+        and rm_r["improve"] >= args.fail_below_r
+        and (args.skip_calib_check or calib_ok)
+    )
+    if pass_cond:
+        print("APPLY PASS")
+    else:
+        print("APPLY FAIL")
+        reasons = []
+        if rm_y["improve"] < args.fail_below_y:
+            reasons.append(
+                f"Δy improve {100*rm_y['improve']:.1f}% < target {100*args.fail_below_y:.1f}%"
+            )
+        if rm_r["improve"] < args.fail_below_r:
+            reasons.append(
+                f"Δξ2 improve {100*rm_r['improve']:.1f}% < target {100*args.fail_below_r:.1f}%"
+            )
+        if not args.skip_calib_check and not calib_ok:
+            if not (0.7 <= report['calibration']['y'] <= 1.3):
+                reasons.append(
+                    f"Calib_y {report['calibration']['y']:.2f} not in [0.7,1.3]"
+                )
+            if not (0.7 <= report['calibration']['r'] <= 1.3):
+                reasons.append(
+                    f"Calib_r {report['calibration']['r']:.2f} not in [0.7,1.3]"
+                )
+        if reasons:
+            print("Reasons:", "; ".join(reasons))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/04_eval_mrgpr_slots.py
+++ b/scripts/04_eval_mrgpr_slots.py
@@ -27,10 +27,17 @@ def main() -> None:
     p.add_argument("--gp-y", type=str, required=True)
     p.add_argument("--gp-r", type=str, required=True)
     p.add_argument("--episodes", type=int, default=10)
-    p.add_argument("--steps", type=int, default=200)
-    p.add_argument("--hold", type=int, default=400)
+    p.add_argument("--steps", type=int, default=160)
+    p.add_argument("--hold", type=int, default=0)
     p.add_argument("--seed", type=int, default=0)
     p.add_argument("--improve", type=float, default=0.1)
+    p.add_argument("--yaw-rate", type=float, default=0.35, help="z-axis yaw rate [rad/s]")
+    p.add_argument(
+        "--target-min", type=float, default=0.9, help="minimum target position per axis"
+    )
+    p.add_argument(
+        "--target-max", type=float, default=1.6, help="maximum target position per axis"
+    )
     # MR-GPR trust tuning knobs (conservative defaults)
     p.add_argument("--trust-y", type=float, default=0.35, help="trust scale for Δy slots (0~1)")
     p.add_argument("--trust-r", type=float, default=0.25, help="trust scale for Δξ2 (0~1)")
@@ -38,10 +45,30 @@ def main() -> None:
     p.add_argument("--clip-r", type=float, default=0.1, help="variance clip for Δξ2")
     p.add_argument("--no-y", action="store_true", help="disable Δy correction")
     p.add_argument("--no-r", action="store_true", help="disable Δξ2 correction")
+    p.add_argument(
+        "--ignore-var-trust",
+        action="store_true",
+        help="ignore variance-based gating; use fixed trust scales",
+    )
+    p.add_argument("--cond-aware", action="store_true")
+    p.add_argument("--cond-ref", type=float, default=1e3)
+    p.add_argument("--ood-aware", action="store_true")
+    p.add_argument("--ood-ref", type=float, default=3.0)
+    p.add_argument("--cap-y-ratio", type=float, default=0.5)
+    p.add_argument("--cap-y-abs", type=float, default=2.0)
+    p.add_argument("--cap-r-ratio", type=float, default=0.5)
+    p.add_argument("--cap-r-abs", type=float, default=0.5)
     # reporting
     p.add_argument("--report", action="store_true", help="pretty-print eval summary and failure reasons")
     p.add_argument("--out-json", type=str, default="artifacts/eval_metrics.json")
     p.add_argument("--episodes-csv", type=str, default="artifacts/eval_episode_metrics.csv")
+    p.add_argument("--debug-json", type=str, default="", help="write per-episode MRGP stats")
+    p.add_argument(
+        "--offline-apply-json",
+        type=str,
+        default="",
+        help="path to offline_apply_report.json for bookkeeping",
+    )
     args = p.parse_args()
 
     gp_y = ResidualYSlotsGP.load(args.gp_y)
@@ -50,16 +77,20 @@ def main() -> None:
     rng = np.random.default_rng(args.seed)
 
     metrics = {"baseline": [], "mrgp": []}
+    cond_hist = {"baseline": [], "mrgp": []}
     episode_rows = []  # collect per-episode metrics for CSV
+    debug_rows = []
     for _ in range(args.episodes):
-        target = rng.uniform(0.6, 1.2, size=3)
+        target = rng.uniform(args.target_min, args.target_max, size=3)
+        omega_refs = [np.array([0.0, 0.0, args.yaw_rate])] * args.steps
 
         quad_base = SlotCorrectedController(gp_fx=None, gp_fr=None)
         pos_b, forces_b, _, _, x_refs_b, _, conds_b, _ = simulate(
-            args.steps, target=target, hold_steps=args.hold, quad=quad_base
+            args.steps, target=target, hold_steps=args.hold, omega_refs=omega_refs, quad=quad_base
         )
         m_b = _metrics(pos_b, x_refs_b, forces_b, conds_b, target, quad_base.max_force)
         metrics["baseline"].append(m_b)
+        cond_hist["baseline"].append(conds_b)
         episode_rows.append(("baseline",) + m_b)
 
         ts_y = 0.0 if args.no_y else args.trust_y
@@ -71,13 +102,24 @@ def main() -> None:
             trust_scale_r=ts_r,
             var_clip_y=args.clip_y,
             var_clip_r=args.clip_r,
+            ignore_var_trust=args.ignore_var_trust,
+            cond_aware=args.cond_aware,
+            cond_ref=args.cond_ref,
+            ood_aware=args.ood_aware,
+            ood_ref=args.ood_ref,
+            cap_y_ratio=args.cap_y_ratio,
+            cap_y_abs=args.cap_y_abs,
+            cap_r_ratio=args.cap_r_ratio,
+            cap_r_abs=args.cap_r_abs,
         )
         pos_m, forces_m, _, _, x_refs_m, _, conds_m, _ = simulate(
-            args.steps, target=target, hold_steps=args.hold, quad=quad_mrgp
+            args.steps, target=target, hold_steps=args.hold, omega_refs=omega_refs, quad=quad_mrgp
         )
         m_m = _metrics(pos_m, x_refs_m, forces_m, conds_m, target, quad_mrgp.max_force)
         metrics["mrgp"].append(m_m)
+        cond_hist["mrgp"].append(conds_m)
         episode_rows.append(("mrgp",) + m_m)
+        debug_rows.append(quad_mrgp.get_debug_stats())
 
     metrics_avg = {}
     for key, vals in metrics.items():
@@ -90,9 +132,54 @@ def main() -> None:
             "cond_violate": float(np.mean(arr[:, 4])),
         }
 
+    cond_percentiles = {}
+    for key, arrs in cond_hist.items():
+        concat = np.concatenate(arrs) if arrs else np.array([])
+        if concat.size:
+            cond_percentiles[key] = np.percentile(concat, [50, 90, 99])
+        else:
+            cond_percentiles[key] = np.array([float("nan")]*3)
+    if debug_rows:
+        keys = debug_rows[0].keys()
+        debug_summary = {k: float(np.mean([d[k] for d in debug_rows])) for k in keys}
+    else:
+        debug_summary = {}
+
     os.makedirs("artifacts", exist_ok=True)
+    report = {
+        "baseline": metrics_avg["baseline"],
+        "mrgp": metrics_avg["mrgp"],
+        "cond_percentiles": {k: cond_percentiles[k].tolist() for k in cond_percentiles},
+        "config": {
+            "episodes": args.episodes,
+            "steps": args.steps,
+            "hold": args.hold,
+            "yaw_rate": args.yaw_rate,
+            "target_min": args.target_min,
+            "target_max": args.target_max,
+            "trust_y": args.trust_y,
+            "trust_r": args.trust_r,
+            "clip_y": args.clip_y,
+            "clip_r": args.clip_r,
+            "ignore_var_trust": args.ignore_var_trust,
+            "cond_aware": args.cond_aware,
+            "cond_ref": args.cond_ref,
+            "ood_aware": args.ood_aware,
+            "ood_ref": args.ood_ref,
+            "cap_y_ratio": args.cap_y_ratio,
+            "cap_y_abs": args.cap_y_abs,
+            "cap_r_ratio": args.cap_r_ratio,
+            "cap_r_abs": args.cap_r_abs,
+            "seed": args.seed,
+            "offline_apply_json": args.offline_apply_json,
+        },
+        "debug_summary": debug_summary,
+    }
     with open(args.out_json, "w") as fh:
-        json.dump(metrics_avg, fh)
+        json.dump(report, fh)
+    if args.debug_json:
+        with open(args.debug_json, "w") as fh:
+            json.dump({"episodes": debug_rows, "summary": debug_summary}, fh)
 
     # write per-episode CSV
     try:
@@ -117,6 +204,17 @@ def main() -> None:
         print("\n=== MR-GPR Evaluation (summary) ===")
         print(f"Baseline:  final_err={b['final_err']:.3f}  rms_err={b['rms_err']:.3f}  sat={_pct(b['sat_pct'])}  cond_mean={b['cond_mean']:.1f}  cond_viol={_pct(b['cond_violate'])}")
         print(f"MR-GPR:    final_err={m['final_err']:.3f}  rms_err={m['rms_err']:.3f}  sat={_pct(m['sat_pct'])}  cond_mean={m['cond_mean']:.1f}  cond_viol={_pct(m['cond_violate'])}")
+        qb = cond_percentiles["baseline"]
+        qm = cond_percentiles["mrgp"]
+        print(
+            f"Baseline condA p50/p90/p99: {qb[0]:.1f}/{qb[1]:.1f}/{qb[2]:.1f}"
+        )
+        print(
+            f"MR-GPR  condA p50/p90/p99: {qm[0]:.1f}/{qm[1]:.1f}/{qm[2]:.1f}"
+        )
+        print(
+            f"MR-GPR applied on {100.0 * debug_summary.get('applied_ratio', 0.0):.1f}% of steps"
+        )
         print(f"→ rms improvement={100 * improve:.1f}%  Δsat={_pct(sat_increase)}  ΔcondViol={_pct(cond_increase)}")
 
     pass_cond = (

--- a/simulation.py
+++ b/simulation.py
@@ -342,6 +342,7 @@ def simulate(
     steps: int = 100,
     target: np.ndarray | None = None,
     hold_steps: int = 0,
+    omega_refs: list[np.ndarray] | None = None,
     quad: Quadrotor | None = None,
 ):
     """Run the quadrotor simulation and optionally hold at the goal."""
@@ -367,9 +368,14 @@ def simulate(
         [],
         [],
     )
+    yaw_ref = 0.0
     for k in range(len(traj)):
         x_ref, v_ref, a_ref = traj[k]
-        f, R, x_r, R_ref, err, condA, offD = quad.step(x_ref, v_ref, a_ref)
+        if omega_refs is not None and k < len(omega_refs):
+            yaw_ref += float(omega_refs[k][2]) * quad.dt
+        f, R, x_r, R_ref, err, condA, offD = quad.step(
+            x_ref, v_ref, a_ref, yaw_ref=yaw_ref
+        )
         positions.append(quad.x.copy())
         forces.append(f)
         R_hist.append(R)

--- a/tests/test_offline_apply_check.py
+++ b/tests/test_offline_apply_check.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "offline_check", Path(__file__).resolve().parents[1] / "scripts" / "03b_offline_apply_check.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[arg-type]
+    return mod
+
+
+def test_offline_apply_check(tmp_path):
+    mod = load_module()
+    rng = np.random.default_rng(0)
+    X_y = rng.normal(size=(20, 39))
+    Y_y = rng.normal(size=(20, 9))
+    X_r = rng.normal(size=(20, 33))
+    Y_r = rng.normal(size=(20, 3))
+    data_path = tmp_path / "data.npz"
+    np.savez(data_path, X_y=X_y, Y_y=Y_y, X_r=X_r, Y_r=Y_r)
+
+    class Dummy:
+        def __init__(self, Y):
+            self.Y = Y
+        def predict(self, X):  # noqa: D401 - simple dummy
+            return self.Y, np.ones_like(self.Y)
+
+    gp_y = Dummy(Y_y)
+    gp_r = Dummy(Y_r)
+    out_json = tmp_path / "report.json"
+    out_csv = tmp_path / "dims.csv"
+    report = mod.offline_apply_check(
+        data=str(data_path),
+        gp_y="",
+        gp_r="",
+        out_json=str(out_json),
+        out_csv=str(out_csv),
+        skip_calib_check=True,
+        gp_y_model=gp_y,
+        gp_r_model=gp_r,
+    )
+    assert "rmse" in report and "calibration" in report
+    assert "improve_dim" in report and "shuffle" in report
+    assert report["rmse"]["y"]["improve"] > 0.0
+    assert out_json.exists() and out_csv.exists()
+    loaded = json.loads(out_json.read_text())
+    assert "rmse" in loaded

--- a/tests/test_var_gating_flag.py
+++ b/tests/test_var_gating_flag.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from control.controller_mrgpr_slots import MRGPBlockController
+
+
+class FakeGP:
+    def __init__(self, out_dim: int, mean: float = 1.0, var: float = 100.0) -> None:
+        self.out_dim = out_dim
+        self.mean = mean
+        self.var = var
+
+    def predict(self, X: np.ndarray):
+        n = X.shape[0]
+        return (
+            np.full((n, self.out_dim), self.mean),
+            np.full((n, self.out_dim), self.var),
+        )
+
+
+def test_ignore_var_trust_overrides_gating() -> None:
+    gp_y = FakeGP(9, mean=1.0, var=100.0)
+    gp_r = FakeGP(3, mean=1.0, var=100.0)
+
+    ctrl_on = MRGPBlockController(
+        gp_y,
+        gp_r,
+        trust_scale_y=0.7,
+        trust_scale_r=0.5,
+        var_clip_y=0.1,
+        var_clip_r=0.1,
+        ignore_var_trust=True,
+    )
+    ctrl_off = MRGPBlockController(
+        gp_y,
+        gp_r,
+        trust_scale_y=0.7,
+        trust_scale_r=0.5,
+        var_clip_y=0.1,
+        var_clip_r=0.1,
+        ignore_var_trust=False,
+    )
+    # Dummy predictions
+    X_dummy = np.zeros((1, 1))
+    dy, vy = gp_y.predict(X_dummy)
+    dr, vr = gp_r.predict(X_dummy)
+
+    wy_off = 0.7 * (1.0 / (1.0 + vy[0] / 0.1))
+    wr_off = 0.5 * (1.0 / (1.0 + vr[0] / 0.1))
+    wy_on = 0.7
+    wr_on = 0.5
+
+    assert np.allclose(wy_on, 0.7) and np.all(wy_off < 0.01)
+    assert np.allclose(wr_on, 0.5) and np.all(wr_off < 0.01)
+
+    # ensure controllers stored flag properly (sanity)
+    assert ctrl_on.ignore_var_trust is True
+    assert ctrl_off.ignore_var_trust is False


### PR DESCRIPTION
## Summary
- add `03b_offline_apply_check.py` to measure offline GP correction improvements, calibration, and shuffle baselines
- support optional variance-gating override in MR-GPR controller and evaluation CLI, with tests
- enable optional cond/OOD-aware scaling with correction caps and debug logging in MRGP controller, wired through evaluation script

## Testing
- `python -m data.build_slots_td --runs 6 --steps 160 --hold 40 --seed 0 --yaw-rate 0.35 --target-min 0.9 --target-max 1.6 --out artifacts/slots_td.npz`
- `python scripts/02_train_slots_gp.py --data artifacts/slots_td.npz --out-y artifacts/gp_y.pkl --out-r artifacts/gp_r.pkl --val-split 0.2 --seed 0 --fast --subsample 800 --calibrate`
- `python scripts/03b_offline_apply_check.py --data artifacts/slots_td.npz --gp-y artifacts/gp_y.pkl --gp-r artifacts/gp_r.pkl --out-json artifacts/offline_apply_report.json --out-csv artifacts/offline_apply_dims.csv --fail-below-y 0.10 --fail-below-r 0.10 --shuffle-runs 3 --seed 0 --skip-calib-check`
- `python scripts/04_eval_mrgpr_slots.py --gp-y artifacts/gp_y.pkl --gp-r artifacts/gp_r.pkl --episodes 8 --steps 160 --hold 0 --yaw-rate 0.35 --target-min 0.9 --target-max 1.6 --trust-y 0.2 --trust-r 0.1 --clip-y 1.0 --clip-r 0.3 --ignore-var-trust --improve 0.0 --report --out-json artifacts/eval_ignore_smalltrust.json --episodes-csv artifacts/eval_ignore_smalltrust.csv --debug-json artifacts/eval_ignore_smalltrust_debug.json`
- `python scripts/04_eval_mrgpr_slots.py --gp-y artifacts/gp_y.pkl --gp-r artifacts/gp_r.pkl --episodes 8 --steps 160 --hold 0 --yaw-rate 0.35 --target-min 0.9 --target-max 1.6 --trust-y 0.8 --trust-r 0.6 --clip-y 1.0 --clip-r 0.3 --cond-aware --cond-ref 1e3 --ood-aware --ood-ref 3.0 --cap-y-ratio 0.5 --cap-y-abs 2.0 --cap-r-ratio 0.5 --cap-r-abs 0.5 --improve 0.0 --report --out-json artifacts/eval_cond_ood_cap.json --episodes-csv artifacts/eval_cond_ood_cap.csv --debug-json artifacts/eval_cond_ood_cap_debug.json`
- `python - <<'PY'
import json

def imp(p):
  m=json.load(open(p)); b,mr=m['baseline'],m['mrgp']
  return 100*(b['rms_err']-mr['rms_err'])/max(b['rms_err'],1e-9)
print("ignore_smalltrust  : %.2f%%" % imp("artifacts/eval_ignore_smalltrust.json"))
print("cond_ood_cap       : %.2f%%" % imp("artifacts/eval_cond_ood_cap.json"))
PY`
- `pytest -q`


------